### PR TITLE
feat: publish signed assessment release package

### DIFF
--- a/.github/workflows/dev-push.yml
+++ b/.github/workflows/dev-push.yml
@@ -19,10 +19,10 @@ jobs:
         submodules: true
         fetch-depth: 2
         token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install Trestle
       run: bash scripts/automation/install_trestle.sh
     - name: Automatically update content on push

--- a/.github/workflows/main-push.yml
+++ b/.github/workflows/main-push.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Release
@@ -13,14 +17,24 @@ jobs:
         submodules: true
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install Trestle
       run: bash scripts/automation/install_trestle.sh
     - name: Release
       run: source scripts/automation/release.sh
+    - name: Publish signed assessment package
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SSP_RELEASE_REPOSITORY: oscal-compass/e2e-demo-ssp
+        SSP_RELEASE_TAG: ${{ vars.SSP_RELEASE_TAG }}
+        SSP_SIGNING_PUBLIC_KEY: ${{ secrets.SSP_SIGNING_PUBLIC_KEY }}
+        ASSESSMENT_SIGNING_PRIVATE_KEY: ${{ secrets.ASSESSMENT_SIGNING_PRIVATE_KEY }}
+        ASSESSMENT_SIGNING_KEY_PASSWORD: ${{ secrets.ASSESSMENT_SIGNING_KEY_PASSWORD }}
+        ASSESSMENT_SIGNING_PUBLIC_KEY: ${{ secrets.ASSESSMENT_SIGNING_PUBLIC_KEY }}
+      run: bash scripts/automation/publish_signed_assessment_package.sh
     - name: Push the changes
       run: bash scripts/automation/push.sh
   merge-main-to-develop:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The end-to-end demo [overview](https://github.com/oscal-compass/e2e-demo).
 <br/>
 The end-to-end-demo [compliance posture portion](https://github.com/oscal-compass/e2e-demo#demo-2---cncf-oscal-compass-automated-compliance-posture) instructions.
 
+See [Signed assessment releases](SIGNED_RELEASES.md) for package verification instructions.
+
 Last updated: *2025-03-27 12:56:11*
 
 <hr>

--- a/SIGNED_RELEASES.md
+++ b/SIGNED_RELEASES.md
@@ -1,0 +1,55 @@
+# Signed assessment releases
+
+The `main` release workflow verifies a configured SSP release before publishing a signed assessment-results package. The package contains the current assessment results, the component definitions consumed by the compliance-posture calculation, and the complete verified SSP package.
+
+The assessment package signature covers the canonical SHA-256 digests of the assessment inputs and the upstream SSP manifest. The nested SSP signature separately proves the integrity and approval of the SSP artifacts. Consumers must verify both layers.
+
+The current assessment output is a JSON results collection rather than a complete top-level OSCAL Assessment Results document, so the workflow creates its package manifest explicitly instead of using `trestle generate-manifest`.
+
+## Repository configuration
+
+Set the `SSP_RELEASE_TAG` repository variable to the SSP release consumed by this workflow, for example `v0.3.0`.
+
+Configure these GitHub Actions secrets:
+
+- `SSP_SIGNING_PUBLIC_KEY`: the independently trusted public key for SSP package verification;
+- `ASSESSMENT_SIGNING_PRIVATE_KEY`: the encrypted PEM private key used to sign the assessment package;
+- `ASSESSMENT_SIGNING_KEY_PASSWORD`: the private-key password;
+- `ASSESSMENT_SIGNING_PUBLIC_KEY`: the public key used to verify the assessment package before publication.
+
+Generate an encrypted Ed25519 assessment key pair locally:
+
+```bash
+export ASSESSMENT_SIGNING_KEY_PASSWORD='replace-with-a-strong-password'
+openssl genpkey -algorithm ed25519 -aes-256-cbc \
+  -pass env:ASSESSMENT_SIGNING_KEY_PASSWORD \
+  -out assessment-private.pem
+openssl pkey -in assessment-private.pem \
+  -passin env:ASSESSMENT_SIGNING_KEY_PASSWORD \
+  -pubout -out assessment-public.pem
+chmod 600 assessment-private.pem
+```
+
+Store the private key, password, and public key as the corresponding `ASSESSMENT_SIGNING_*` secrets. Obtain `SSP_SIGNING_PUBLIC_KEY` independently from the maintainers of the SSP release; do not take a replacement key from the release being verified.
+
+## Verification
+
+Download and extract `assessment-results-package-<tag>.tar.gz`, then verify the assessment package with an independently trusted assessment public key:
+
+```bash
+trestle verify-manifest \
+  --beta \
+  --manifest assessment-signing-manifest.json \
+  --signature assessment-signing-manifest.dsse \
+  --public-key trusted-assessment-public.pem
+```
+
+Verify the nested SSP package with its independently trusted public key:
+
+```bash
+trestle verify-manifest \
+  --beta \
+  --manifest upstream/ssp/ssp-signing-manifest.json \
+  --signature upstream/ssp/ssp-signing-manifest.dsse \
+  --public-key trusted-ssp-public.pem
+```

--- a/component-definitions/oscap/component-definition.json
+++ b/component-definitions/oscap/component-definition.json
@@ -1670,8 +1670,7 @@
             "value": "Ubuntu_Linux_24.04_LTS",
             "remarks": "rule_set_68"
           }
-        ],
-        "control-implementations": []
+        ]
       }
     ]
   }

--- a/python/compliance_posture.py
+++ b/python/compliance_posture.py
@@ -199,6 +199,10 @@ class CompliancePosture():
         self.markdown_helper.add_line('<br/>')
         self.markdown_helper.add_line('The end-to-end-demo [compliance posture portion](https://github.com/oscal-compass/e2e-demo#demo-2---cncf-oscal-compass-automated-compliance-posture) instructions.')
         self.markdown_helper.add_line('')
+        self.markdown_helper.add_line(
+            'See [Signed assessment releases](SIGNED_RELEASES.md) for package verification instructions.'
+        )
+        self.markdown_helper.add_line('')
 
         now = datetime.now()
         datetime_without_ms = now.strftime('%Y-%m-%d %H:%M:%S')

--- a/scripts/automation/install_trestle.sh
+++ b/scripts/automation/install_trestle.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 python3 -m pip install --upgrade pip setuptools
-python3 -m pip install compliance-trestle
+python3 -m pip install 'compliance-trestle>=5.0.0'
 python3 -m pip install python-semantic-release==7.31.4

--- a/scripts/automation/publish_signed_assessment_package.sh
+++ b/scripts/automation/publish_signed_assessment_package.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+required_variables=(
+    VERSION_TAG
+    GH_TOKEN
+    GITHUB_REPOSITORY
+    SSP_RELEASE_TAG
+    SSP_SIGNING_PUBLIC_KEY
+    ASSESSMENT_SIGNING_PRIVATE_KEY
+    ASSESSMENT_SIGNING_KEY_PASSWORD
+    ASSESSMENT_SIGNING_PUBLIC_KEY
+)
+
+for variable in "${required_variables[@]}"; do
+    if [[ -z "${!variable:-}" ]]; then
+        echo "Required environment variable is not set: ${variable}" >&2
+        exit 1
+    fi
+done
+
+if [[ ! "${VERSION_TAG}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] ||
+    [[ ! "${SSP_RELEASE_TAG}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+    echo 'Release tags contain unsupported characters.' >&2
+    exit 1
+fi
+
+ssp_repository="${SSP_RELEASE_REPOSITORY:-oscal-compass/e2e-demo-ssp}"
+release_tag="v${VERSION_TAG#v}"
+work_dir=$(mktemp -d "${RUNNER_TEMP:-/tmp}/assessment-signing.XXXXXX")
+package_root="${work_dir}/package"
+ssp_root="${package_root}/upstream/ssp"
+ssp_extract_root="${work_dir}/ssp-extracted"
+assessment_manifest="${package_root}/assessment-signing-manifest.json"
+assessment_envelope="${package_root}/assessment-signing-manifest.dsse"
+assessment_archive="${work_dir}/assessment-results-package-${release_tag}.tar.gz"
+
+cleanup() {
+    rm -rf "${work_dir}"
+}
+trap cleanup EXIT
+
+umask 077
+mkdir -p "${ssp_root}" "${ssp_extract_root}"
+printf '%s\n' "${SSP_SIGNING_PUBLIC_KEY}" > "${work_dir}/ssp-public.pem"
+printf '%s\n' "${ASSESSMENT_SIGNING_PRIVATE_KEY}" > "${work_dir}/assessment-private.pem"
+printf '%s\n' "${ASSESSMENT_SIGNING_PUBLIC_KEY}" > "${work_dir}/assessment-public.pem"
+
+ssp_archive="${work_dir}/ssp-package-${SSP_RELEASE_TAG}.tar.gz"
+gh release download "${SSP_RELEASE_TAG}" \
+    --repo "${ssp_repository}" \
+    --pattern "$(basename "${ssp_archive}")" \
+    --dir "${work_dir}"
+
+python3 - "${ssp_archive}" "${ssp_extract_root}" <<'PY'
+import pathlib
+import sys
+import tarfile
+
+archive = pathlib.Path(sys.argv[1])
+destination = pathlib.Path(sys.argv[2])
+with tarfile.open(archive, 'r:gz') as package:
+    package.extractall(destination, filter='data')
+PY
+
+python3 - "${ssp_extract_root}" "${ssp_root}" <<'PY'
+import json
+import pathlib
+import shutil
+import sys
+
+source_root = pathlib.Path(sys.argv[1]).resolve()
+destination_root = pathlib.Path(sys.argv[2]).resolve()
+manifest_name = 'ssp-signing-manifest.json'
+envelope_name = 'ssp-signing-manifest.dsse'
+
+with (source_root / manifest_name).open(encoding='utf-8') as manifest_file:
+    manifest = json.load(manifest_file)
+
+artifact_paths = [pathlib.PurePosixPath(artifact['uri']) for artifact in manifest['artifacts']]
+artifact_paths.extend((pathlib.PurePosixPath(manifest_name), pathlib.PurePosixPath(envelope_name)))
+
+for artifact_path in artifact_paths:
+    if artifact_path.is_absolute() or '..' in artifact_path.parts:
+        raise ValueError(f'Unsafe SSP package artifact path: {artifact_path}')
+    source = (source_root / pathlib.Path(*artifact_path.parts)).resolve()
+    if not source.is_relative_to(source_root) or not source.is_file():
+        raise ValueError(f'Invalid SSP package artifact: {artifact_path}')
+    destination = destination_root / pathlib.Path(*artifact_path.parts)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+PY
+
+trestle verify-manifest \
+    --beta \
+    --manifest "${ssp_root}/ssp-signing-manifest.json" \
+    --signature "${ssp_root}/ssp-signing-manifest.dsse" \
+    --public-key "${work_dir}/ssp-public.pem"
+
+copy_artifact() {
+    local source=$1
+    local destination="${package_root}/${source}"
+    test -f "${source}"
+    mkdir -p "$(dirname "${destination}")"
+    cp "${source}" "${destination}"
+}
+
+assessment_results="assessment-results/ubuntu2404/results.json"
+software_definition="component-definitions/Ubuntu_Linux_24.04_LTS/component-definition.json"
+validation_definition="component-definitions/oscap/component-definition.json"
+ssp_manifest="upstream/ssp/ssp-signing-manifest.json"
+
+copy_artifact "${assessment_results}"
+copy_artifact "${software_definition}"
+copy_artifact "${validation_definition}"
+
+jq -n \
+    --arg assessment_results "${assessment_results}" \
+    --arg software_definition "${software_definition}" \
+    --arg validation_definition "${validation_definition}" \
+    --arg ssp_manifest "${ssp_manifest}" \
+    '{
+        primaryArtifact: $assessment_results,
+        artifacts: [
+            {name: $assessment_results, uri: $assessment_results, mediaType: "application/json"},
+            {name: $software_definition, uri: $software_definition, mediaType: "application/oscal+json"},
+            {name: $validation_definition, uri: $validation_definition, mediaType: "application/oscal+json"},
+            {name: $ssp_manifest, uri: $ssp_manifest, mediaType: "application/json"}
+        ]
+    }' > "${assessment_manifest}"
+
+trestle sign-manifest \
+    --beta \
+    --manifest "${assessment_manifest}" \
+    --private-key "${work_dir}/assessment-private.pem" \
+    --key-password-env ASSESSMENT_SIGNING_KEY_PASSWORD \
+    -o "${assessment_envelope}"
+
+trestle verify-manifest \
+    --beta \
+    --manifest "${assessment_manifest}" \
+    --signature "${assessment_envelope}" \
+    --public-key "${work_dir}/assessment-public.pem"
+
+tar -czf "${assessment_archive}" -C "${package_root}" .
+gh release upload "${release_tag}" "${assessment_archive}" --repo "${GITHUB_REPOSITORY}"

--- a/scripts/automation/release.sh
+++ b/scripts/automation/release.sh
@@ -1,8 +1,9 @@
+#!/usr/bin/env bash
+
 version_tag=$(semantic-release print-version)
-echo "Bumping version of profiles to ${version_tag}" 
+echo "Preparing release ${version_tag}"
 export VERSION_TAG="$version_tag"
-echo "VERSION_TAG=${VERSION_TAG}" >> $GITHUB_ENV
-./scripts/automation/assemble_ssp.sh $version_tag
+echo "VERSION_TAG=${VERSION_TAG}" >> "$GITHUB_ENV"
 git config --global user.email "automation@example.com"
 git config --global user.name "Automation Bot" 
 semantic-release publish


### PR DESCRIPTION
## Summary

Extends the compliance-posture release workflow with a signed assessment package. The workflow downloads the configured SSP release, verifies its signed package, and includes it with the assessment results and component definitions.

The assessment package is signed as a DSSE envelope. Both the assessment package and nested SSP package remain independently verifiable.

The current `results.json` is a custom results collection rather than a complete OSCAL Assessment Results document with `import-ap`. Therefore, the package manifest is created explicitly instead of using automatic dependency discovery.

## Changes and Configuration

The release publishes `assessment-results-package-<tag>.tar.gz`. The workflows now use Python 3.11 and Trestle 5.

Maintainers must set the `SSP_RELEASE_TAG` repository variable and configure the `SSP_SIGNING_PUBLIC_KEY`, `ASSESSMENT_SIGNING_PRIVATE_KEY`, `ASSESSMENT_SIGNING_KEY_PASSWORD`, and `ASSESSMENT_SIGNING_PUBLIC_KEY` secrets. The SSP public key must be obtained independently from the SSP maintainers. 

Related to oscal-compass/e2e-demo#22.